### PR TITLE
PLACE_TYPE.xlsx file path mentioned twice.

### DIFF
--- a/configuration/developing-community-health-applications.md
+++ b/configuration/developing-community-health-applications.md
@@ -76,8 +76,8 @@ To create the above XForm files it is recommended to use XLSForms. Also, if the 
 
     - /forms/contact/person-create.xlsx
     - /forms/contact/person-edit.xlsx
-    - /forms/contact/PLACE_TYPE.xlsx
-    - /forms/contact/PLACE_TYPE.xlsx
+    - /forms/contact/PLACE_TYPE-create.xlsx
+    - /forms/contact/PLACE_TYPE-edit.xlsx
     - /forms/contact/places.json
 
 Here is an example of a `places.json` files: 


### PR DESCRIPTION
The section on Contact forms, lists the base files required but lists PLACE_TYPE.xlsx twice, I think the intention was to use the file names `PLACE_TYPE-create.xlsx` and `PLACE_TYPE-edit.xlsx` so I have edited the text accordingly.