### PR TITLE
Actually 2.x does need a specific version of medic-couch2pg

### DIFF
--- a/installation/supported-software.md
+++ b/installation/supported-software.md
@@ -3,5 +3,5 @@
 | medic | Node | CouchDB | Browsers | SMS bridge | Android | medic-android | medic-couch2pg |
 |----|----|----|----|----|----|----|---|
 | **0.4** | 0.12+ | 1.6+ | Chrome 30+, Firefox latest | SMSSync | N/A | N/A | N/A |
-| **2.x** | 6+ | 1.6+ | Chrome 30+, Firefox latest | medic-gateway | 4.4+ | Any | 2.0+ |
+| **2.x** | 6+ | 1.6+ | Chrome 30+, Firefox latest | medic-gateway | 4.4+ | Any | 2.0 < 3.0 |
 | **3.x** | 8.11+ | 2.1+ | Chrome 53+, Firefox latest | medic-gateway | 4.4+ | 0.4.5+ | 3.0+


### PR DESCRIPTION
@vimemo I did not realise / had forgotten that this was the case. Just to confirm though, versions of our app that don't have medic-sentinel (so <3.0.0) won't work on the newer version, correct?