### PR TITLE
CHT docker install updates

### DIFF
--- a/installation/public-docker-image-setup.md
+++ b/installation/public-docker-image-setup.md
@@ -15,7 +15,7 @@ Mac OSX:
 - [Docker for Mac](https://download.docker.com/mac/stable/Docker.dmg)
 
 Windows:
-- *Note*: If you have Hyper-V Capability, please ensure it is enabled in order to run Linux Containers on Windows. If you are running your Windows Server in cloud services, please ensure it is running on bare-mental. You will not be able to run Linux Containers in Windows if the previous comments are not adhered due to nested virtualization. 
+- *Note*: If you have Hyper-V Capability, please ensure it is enabled in order to run Linux Containers on Windows. If you are running your Windows Server in cloud services, please ensure it is running on bare-metal. You will not be able to run Linux Containers in Windows if the previous comments are not adhered due to nested virtualization. 
 - [Docker for Windows](https://download.docker.com/win/stable/Docker%20for%20Windows%20Installer.exe)
 - *Note*: If you do not have Hyper-V capability, but your server still supports virtualization, ensure that is enabled in your BiOS, and install the following package:
 - [Docker Toolbox using VirtualBox](https://github.com/docker/toolbox/releases)

--- a/installation/public-docker-image-setup.md
+++ b/installation/public-docker-image-setup.md
@@ -6,20 +6,18 @@ This document should help you quickly install the necessary tools to download an
 
 ## Download Docker
 
-Ubuntu:
-`Docker CE` :
-- [] [Docker CE](https://docs.docker.com/install/linux/docker-ce/ubuntu/)
-- [] [Docker-Compose](https://docs.docker.com/compose/install/)
+Ubuntu: 
+- *Note*: Install both below
+- [Docker CE](https://docs.docker.com/install/linux/docker-ce/ubuntu/)
+- [Docker-Compose](https://docs.docker.com/compose/install/)
 
 Mac OSX:
-` Docker for Mac` : 
-[Docker for Mac](https://download.docker.com/mac/stable/Docker.dmg)
+- [Docker for Mac](https://download.docker.com/mac/stable/Docker.dmg)
 
 *Note*: In order to run Linux Containers on Windows, please ensure Hyper-V is enabled, and the host is running on bare-metal. You will not be able to run Linux Containers in Windows if the previous comments are not adhered due to nested virtualization. 
 
 Windows:
-` Docker for Windows` :
-[Docker for Windows](https://download.docker.com/win/stable/Docker%20for%20Windows%20Installer.exe)
+- [Docker for Windows](https://download.docker.com/win/stable/Docker%20for%20Windows%20Installer.exe)
 
 Run the installation and follow the instructions.
 

--- a/installation/public-docker-image-setup.md
+++ b/installation/public-docker-image-setup.md
@@ -7,7 +7,9 @@ This document should help you quickly install the necessary tools to download an
 ## Download Docker
 
 Ubuntu:
-`Docker CE`:[Docker CE](https://docs.docker.com/install/linux/docker-ce/ubuntu/)
+`Docker CE` :
+- [] [Docker CE](https://docs.docker.com/install/linux/docker-ce/ubuntu/)
+- [] [Docker-Compose](https://docs.docker.com/compose/install/)
 
 Mac OSX:
 ` Docker for Mac` : 
@@ -83,6 +85,7 @@ Inside the directory that you saved the above <project_name>-medic-os-compose.ym
 ```
 $ docker-compose -f <project_name>-medic-os-compose.yml up
 ```
+*Note* In certain shells, docker-compose may not interpolate the admin password that was exported above. In that case, your admin user had a password automatically generated. You can find this in your terminal, or parsing the initial setup logs in via `docker logs medic-os`
 
 Once containers are setup, please run the following command from your host terminal:
 ```
@@ -93,7 +96,7 @@ $ docker exec -it medic-os /bin/bash -c "/boot/svc-stop medic-core openssh && /b
 ### Container Manipulation
 
 Stop containers:
-`docker-compose down` || `docker stop medic-os && docker stop haproxy`
+`docker-compose down` or `docker stop medic-os && docker stop haproxy`
 
 Remove containers & clean data volume:
 `docker rm medic-os && docker rm haproxy && docker volume rm medic-data`

--- a/installation/public-docker-image-setup.md
+++ b/installation/public-docker-image-setup.md
@@ -6,15 +6,20 @@ This document should help you quickly install the necessary tools to download an
 
 ## Download Docker
 
+Ubuntu:
+`Docker CE`:[Docker CE](https://docs.docker.com/install/linux/docker-ce/ubuntu/)
+
 Mac OSX:
 ` Docker for Mac` : 
 [Docker for Mac](https://download.docker.com/mac/stable/Docker.dmg)
+
+*Note*: In order to run Linux Containers on Windows, please ensure Hyper-V is enabled, and the host is running on bare-metal. You will not be able to run Linux Containers in Windows if the previous comments are not adhered due to nested virtualization. 
 
 Windows:
 ` Docker for Windows` :
 [Docker for Windows](https://download.docker.com/win/stable/Docker%20for%20Windows%20Installer.exe)
 
-Open the installation and follow the instructions
+Run the installation and follow the instructions
 
 Launch Docker. 
 

--- a/installation/public-docker-image-setup.md
+++ b/installation/public-docker-image-setup.md
@@ -95,19 +95,20 @@ $ docker exec -it medic-os /bin/bash -c "/boot/svc-stop medic-core openssh && /b
 ### Delete & Re-Install
 
 Stop containers:
-`docker-compose down` or `docker stop medic-os && docker stop haproxy`
+* `docker-compose down` or `docker stop medic-os && docker stop haproxy`
 
 Remove containers:
-`docker-compose rm` or `docker rm medic-os && docker rm haproxy`
+* `docker-compose rm` or `docker rm medic-os && docker rm haproxy`
 
 Clean data volume:
-`docker volume rm medic-data`
+* `docker volume rm medic-data`
 
 After following the above three commands, you can re-run `docker-compose up` and create a fresh install (no previous data present)
 
 ### Visit your project
 
 Open a browser to: https://localhost
+
 You will have to click to through the SSL Security warning. Click Advanced -> Continue to site.
 
 
@@ -115,22 +116,19 @@ You will have to click to through the SSL Security warning. Click Advanced -> Co
 
 In case you are already running services on HTTP(80) and HTTPS(443), you will have to map new ports to the medic-os container.
 
-Turn down and remove all existing containers that were started: `docker-compose down && docker-compose rm`
+Turn down and remove all existing containers that were started: 
+* `docker-compose down && docker-compose rm`
 
 To find out which service is using a conflicting port:
-
-On Linux
+On Linux:
 ```
 sudo netstat -plnt | grep ':<port>'
 ```
-
-On Mac (10.10 and above)
+On Mac (10.10 and above):
 ```
 sudo lsof -iTCP -sTCP:LISTEN -n -P | grep ':<port>'
 ```
-
 You can either kill the service which is occupying HTTP/HTTPS ports, or run the container with forwarded ports that are free.
-
 In your compose file, change the ports under medic-os:
 ```
 services:
@@ -147,15 +145,14 @@ services:
 
 ## Helpful Docker commands
 
-```
-# list running containers
-docker ps
+#### list running containers
+* docker ps
 
-# ssh into container/application & view specific service logs
+#### ssh into container/application & view specific service logs
 
 * ssh: `docker exec -it medic-os /bin/bash`
 
-Once inside container:
+#### Once inside container:
 * view couchdb logs: 
   - #less /srv/storage/medic-core/couchdb/logs/startup.log
 * view medic-api logs: 
@@ -164,10 +161,10 @@ Once inside container:
   - #less /srv/storage/medic-sentinel/logs/medic-sentinel.log
 
 
-# View container stderr/stdout logs:
-docker logs medic-os
-docker logs haproxy
-```
+#### View container stderr/stdout logs:
+* docker logs medic-os
+* docker logs haproxy
+
 
 ## Clean Up
 

--- a/installation/public-docker-image-setup.md
+++ b/installation/public-docker-image-setup.md
@@ -14,9 +14,8 @@ Ubuntu:
 Mac OSX:
 - [Docker for Mac](https://download.docker.com/mac/stable/Docker.dmg)
 
-*Note*: In order to run Linux Containers on Windows, please ensure Hyper-V is enabled, and the host is running on bare-metal. You will not be able to run Linux Containers in Windows if the previous comments are not adhered due to nested virtualization. 
-
 Windows:
+- *Note*: In order to run Linux Containers on Windows, please ensure Hyper-V is enabled, and the host is running on bare-metal. You will not be able to run Linux Containers in Windows if the previous comments are not adhered due to nested virtualization. 
 - [Docker for Windows](https://download.docker.com/win/stable/Docker%20for%20Windows%20Installer.exe)
 
 Run the installation and follow the instructions.

--- a/installation/public-docker-image-setup.md
+++ b/installation/public-docker-image-setup.md
@@ -15,8 +15,10 @@ Mac OSX:
 - [Docker for Mac](https://download.docker.com/mac/stable/Docker.dmg)
 
 Windows:
-- *Note*: In order to run Linux Containers on Windows, please ensure Hyper-V is enabled, and the host is running on bare-metal. You will not be able to run Linux Containers in Windows if the previous comments are not adhered due to nested virtualization. 
+- *Note*: If you have Hyper-V Capability, please ensure it is enabled in order to run Linux Containers on Windows. If you are running your Windows Server in cloud services, please ensure it is running on bare-mental. You will not be able to run Linux Containers in Windows if the previous comments are not adhered due to nested virtualization. 
 - [Docker for Windows](https://download.docker.com/win/stable/Docker%20for%20Windows%20Installer.exe)
+- *Note*: If you do not have Hyper-V capability, but your server still supports virtualization, ensure that is enabled in your BiOS, and install the following package:
+- [Docker Toolbox using VirtualBox](https://github.com/docker/toolbox/releases)
 
 Run the installation and follow the instructions.
 

--- a/installation/public-docker-image-setup.md
+++ b/installation/public-docker-image-setup.md
@@ -15,7 +15,7 @@ Mac OSX:
 - [Docker for Mac](https://download.docker.com/mac/stable/Docker.dmg)
 
 Windows:
-- *Note*: If you have Hyper-V Capability, please ensure it is enabled in order to run Linux Containers on Windows. If you are running your Windows Server in cloud services, please ensure it is running on bare-metal. You will not be able to run Linux Containers in Windows if the previous comments are not adhered due to nested virtualization. 
+- *Note*: If you have Hyper-V Capability, please ensure it is enabled in order to run Linux Containers on Windows. If you are running your Windows Server in cloud services, please ensure it is running on [bare-metal](https://en.wikipedia.org/wiki/Bare_machine). You will not be able to run Linux Containers in Windows if the previous comments are not adhered due to nested virtualization. 
 - [Docker for Windows](https://download.docker.com/win/stable/Docker%20for%20Windows%20Installer.exe)
 - *Note*: If you do not have Hyper-V capability, but your server still supports virtualization, ensure that is enabled in your BiOS, and install the following package:
 - [Docker Toolbox using VirtualBox](https://github.com/docker/toolbox/releases)
@@ -38,7 +38,7 @@ version: '3.7'
 services:
   medic-os:
     container_name: medic-os
-    image: medicmobile/medic-os:3.6.1-rc.4
+    image: medicmobile/medic-os:cht-3.7.0-rc.1
     volumes:
       - medic-data:/srv
     ports:
@@ -88,9 +88,12 @@ $ docker-compose -f <project_name>-medic-os-compose.yml up
 
 Once containers are setup, please run the following command from your host terminal:
 ```
-$ docker exec -it medic-os /bin/bash -c "sed -i 's/--install=3.6.1/--complete-install/g' /srv/scripts/horticulturalist/postrun/horticulturalist"
+$ docker exec -it medic-os /bin/bash -c "sed -i 's/--install=3.7.0/--complete-install/g' /srv/scripts/horticulturalist/postrun/horticulturalist"
 $ docker exec -it medic-os /bin/bash -c "/boot/svc-stop medic-core openssh && /boot/svc-stop medic-rdbms && /boot/svc-stop medic-couch2pg"
 ```
+
+The first command fixes a postrun script for horticulturalist to prevent unique scenarios of re-install.
+The second command stops extra services that you will not need.
 
 ### Visit your project
 
@@ -110,6 +113,10 @@ Clean data volume:
 * `docker volume rm medic-data`
 
 After following the above three commands, you can re-run `docker-compose up` and create a fresh install (no previous data present)
+
+## Use Kitematic (GUI for Docker tools)
+
+
 
 ## Port Conflicts
 
@@ -133,7 +140,7 @@ In your compose file, change the ports under medic-os:
 services:
   medic-os:
     container_name: medic-os
-    image: medicmobile/medic-os:3.6.1-rc.4
+    image: medicmobile/medic-os:cht-3.7.0-rc.1
     volumes:
       - medic-data:/srv
     ports:
@@ -143,9 +150,6 @@ services:
 *Note*: You can substitute 8080, 444 with whichever ports are free on your host. You would now visit https://localhost:444 to visit your project.
 
 ## Helpful Docker commands
-
-#### list running containers
-* docker ps
 
 #### ssh into container/application & view specific service logs
 
@@ -165,7 +169,7 @@ services:
 * docker logs haproxy
 
 
-## Clean Up
+#### Clean Up
 
 ```
 # list running containers
@@ -184,3 +188,6 @@ docker start <container_id>
 docker ps -f "status=exited"
 
 ```
+
+#### Prune entire Docker system
+docker system prune

--- a/installation/public-docker-image-setup.md
+++ b/installation/public-docker-image-setup.md
@@ -92,6 +92,12 @@ $ docker exec -it medic-os /bin/bash -c "sed -i 's/--install=3.6.1/--complete-in
 $ docker exec -it medic-os /bin/bash -c "/boot/svc-stop medic-core openssh && /boot/svc-stop medic-rdbms && /boot/svc-stop medic-couch2pg"
 ```
 
+### Visit your project
+
+Open a browser to: https://localhost
+
+You will have to click to through the SSL Security warning. Click Advanced -> Continue to site.
+
 ### Delete & Re-Install
 
 Stop containers:
@@ -104,13 +110,6 @@ Clean data volume:
 * `docker volume rm medic-data`
 
 After following the above three commands, you can re-run `docker-compose up` and create a fresh install (no previous data present)
-
-### Visit your project
-
-Open a browser to: https://localhost
-
-You will have to click to through the SSL Security warning. Click Advanced -> Continue to site.
-
 
 ## Port Conflicts
 


### PR DESCRIPTION
New docker image was published for CHT release: `medicmobile/medic-os:3.6.1-rc.4` 

This includes a lot of fixes related for setup across varying Operating Systems. Documentation has been streamlined and tested for accuracy. Please review docker-compose installation steps.