### PR TITLE
Updated medic references to cht-core in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Documentation
 
 ## Core Framework Development
-The following guides should help orient developers interested in the Core Framework used to build community health apps. Setting up the Core Framework itself is covered in the [medic repo](https://github.com/medic/medic#easy-deployment).
+The following guides should help orient developers interested in the Core Framework used to build community health apps. Setting up the Core Framework itself is covered in the [cht-core repo](https://github.com/medic/cht-core#using-the-core-framework).
 
 ### How we work
-* [Developer environment setup](https://github.com/medic/medic/blob/master/README.md)
+* [Developer environment setup](https://github.com/medic/cht-core/blob/master/README.md)
 * [Using Git](development/using-git.md)
 * [Using npm](development/using-npm.md)
 * [Our workflow](development/workflow.md)
@@ -26,7 +26,7 @@ An introduction and reference for building community health apps is provided in 
 Read more about [building apps with the Core Framework](https://github.com/medic/medic-docs/blob/master/configuration/README.md), and [using other components](https://github.com/medic/medic-docs/blob/master/configuration/README.md#other-components).
 
 ## Maintenance, support, and troubleshooting
-* [Release notes](https://github.com/medic/medic/tree/master/release-notes)
+* [Release notes](https://github.com/medic/cht-core/tree/master/release-notes)
 * [Software compatibility matrix](installation/supported-software.md)
 * [Troubleshooting - Quick Pointers and Tips](troubleshooting/troubleshooting-quick-pointers.md)
 * [Dealing with conflicts](troubleshooting/conflicts.md)


### PR DESCRIPTION
In line with the CHT Core Framework repository update to `cht-core`.