### PR TITLE
update link to core software

### DIFF
--- a/development/architecture.md
+++ b/development/architecture.md
@@ -30,7 +30,7 @@ nginx proxies all requests to api and adds encryption and compression.
 
 ## Client side
 
-### [medic](https://github.com/medic/medic)
+### [cht-core](https://github.com/medic/cht-core)
 
 This is the application that most users interact with. It's an [AngularJS](https://angularjs.org) single page responsive web application.
 


### PR DESCRIPTION
Architecture page still links to /medic/medic. Update to /medic/cht-core