### PR TITLE
Don't default App forms to send SMS

### DIFF
--- a/configuration/forms.md
+++ b/configuration/forms.md
@@ -465,7 +465,7 @@ To get forms sent in this format, follow the [ODK documentation](https://opendat
 
 ### Medic Custom SMS representation
 
-To configure a form to send using Medic's custom SMS definition, the value of `xml2sms` from the form's CouchDB doc should be an string containing an Boolean[Angular expression](https://docs.angularjs.org/guide/expression).
+To configure a form to send using Medic's custom SMS definition, the value of `xml2sms` from the form's CouchDB doc should be an string containing an [Angular expression](https://docs.angularjs.org/guide/expression).
 This allows access to the `fields` property of the `data_record` doc created when saving the form submission to the database.  Extra functions are also provided to make compiling a form submission more simple.
 
 #### Special Functions

--- a/configuration/forms.md
+++ b/configuration/forms.md
@@ -452,19 +452,21 @@ Next you can configure the form to calculate the z-score for a patient using the
 
 ## Sending reports as SMS
 
-When submitting an XForm, along with creating the report document, the app will try to compact the report's content into an SMS that would be sent to the configured Gateway phone number.  
+To define that an XForm should be converted to an SMS, add the field `xml2sms` to the form's CouchDB doc and assign it a truthy value (either a boolean or a string).  
+When submitting such a form, along with creating the report document, the app will try to compact the report's content into an SMS that would be sent to the configured Gateway phone number.
 
 There are two formats available - either using the [ODK's compact record representation for SMS](https://opendatakit.github.io/xforms-spec/#compact-record-representation-(for-sms)), or Medic's custom format.
 When the form compaction fails or returns no content, no SMS will be sent.
 
 ### ODK compact record representation for SMS
 
+When `xml2sms` field value is Boolean `true`, the app will try to compact the form using this format. 
 To get forms sent in this format, follow the [ODK documentation](https://opendatakit.github.io/xforms-spec/#compact-record-representation-(for-sms)).
 
 ### Medic Custom SMS representation
 
-To configure a form to send using Medic's custom SMS definition, add the field `xml2sms` to the form's CouchDB doc.  The value of this field is an [Angular expression](https://docs.angularjs.org/guide/expression), and allows access to the `fields` property of the `data_record` doc created when saving the form submission to the database.  Extra functions are also provided to make compiling a form submission more simple.
-_When `xml2sms` is not set or falsy, ODK compact record representation will be used by default._
+To configure a form to send using Medic's custom SMS definition, the value of `xml2sms` from the form's CouchDB doc should be an string containing an Boolean[Angular expression](https://docs.angularjs.org/guide/expression).
+This allows access to the `fields` property of the `data_record` doc created when saving the form submission to the database.  Extra functions are also provided to make compiling a form submission more simple.
 
 #### Special Functions
 
@@ -579,12 +581,12 @@ There are many supported formats for video, audio, and images. We recommend usin
 
 ## Configuration
 
-To play multimedia from forms you need to add elements to your xml and upload the corresponding multimedia to couchdb as an attachment to your form.  
+To play multimedia from forms you need to add elements to your xml and upload the corresponding multimedia to couchdb as an attachment to your form.
 
 ### Form Config
-  Add an xml element of text and another element of value. Set form equal to the type of multimedia being used(video, audio, image). The value element must contain `jr://file_name.suffix` where `file_name.suffix` is the name of your multimedia file uploaded to couchdb. 
+  Add an xml element of text and another element of value. Set form equal to the type of multimedia being used(video, audio, image). The value element must contain `jr://file_name.suffix` where `file_name.suffix` is the name of your multimedia file uploaded to couchdb.
 
-  Example: 
+  Example:
   ```
   <text id="somevideo">
 	  <value form="video">jr://video.mp4</value>
@@ -599,13 +601,13 @@ To play multimedia from forms you need to add elements to your xml and upload th
   ```
 
 
-  Here is a sample form that will display a video and/or image. When this form is opened a video player will be displayed so the user can watch the video. Forms support displaying of images and playing of audio files. 
+  Here is a sample form that will display a video and/or image. When this form is opened a video player will be displayed so the user can watch the video. Forms support displaying of images and playing of audio files.
 
 ```xml
-  <h:html xmlns="http://www.w3.org/2002/xforms" 
-  xmlns:h="http://www.w3.org/1999/xhtml" 
-  xmlns:ev="http://www.w3.org/2001/xml-events" 
-  xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+  <h:html xmlns="http://www.w3.org/2002/xforms"
+  xmlns:h="http://www.w3.org/1999/xhtml"
+  xmlns:ev="http://www.w3.org/2001/xml-events"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
   xmlns:jr="http://openrosa.org/javarosa">
   <h:head>
     <h:title>Multimedia - Demo Form</h:title>
@@ -653,12 +655,12 @@ To play multimedia from forms you need to add elements to your xml and upload th
 
 ### Couchdb Config
 
-The file needs to be added as an attachment with a name that matches what is defined in the form. This can be added by using curl or fauxton. Here is the structure of the curl command. 
+The file needs to be added as an attachment with a name that matches what is defined in the form. This can be added by using curl or fauxton. Here is the structure of the curl command.
 
 
 `curl -vX PUT https://user:pass@server_name/medic/<form_doc_id>/<attachment_name.suffix>?rev=<latest_form_revision> --data-binary @<local_file_name> -H "Content-Type: <expected_mime_type>"`
 
-Here is an example of how it would look uploading a sample video for the form above. 
+Here is an example of how it would look uploading a sample video for the form above.
 
 ``` curl -vX PUT https://user:pass@localhost/medic/form:multimedia/video.mp4?rev=11-a2ebf09cb9678c031859cd2c1da4b603 -k --data-binary @sample.mp4 -H "Content-Type: video/mp4" ```
 


### PR DESCRIPTION
Updates documentation around compressing app forms to SMS to reflect changes in webapp. 

medic/cht-core#6162